### PR TITLE
docs: change copyright holder in `LICENSE` and copyright notices 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
       - semantic-release
     steps:
       - name: Keep `beta` up to date with `main` (fast-forward enabled)
-        uses: jojomatik/sync-branch@v1
+        uses: johannes-huther/sync-branch@v1
         with:
           git_committer_name: ${{ secrets.BUMP_GIT_NAME }}
           git_committer_email: ${{ secrets.BUMP_GIT_EMAIL }}
@@ -114,7 +114,7 @@ jobs:
       - semantic-release
     steps:
       - name: Keep `updates` up to date with `beta` (fast-forward enabled)
-        uses: jojomatik/sync-branch@v1
+        uses: johannes-huther/sync-branch@v1
         with:
           target: "updates"
           git_committer_name: ${{ secrets.BUMP_GIT_NAME }}

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       # Warning: `beta` MUST include all commits from `main` otherwise the push will fail. This behaviour is not a bug and implemented by design.
       - name: Push `beta` to `main`
-        uses: jojomatik/sync-branch@v1
+        uses: johannes-huther/sync-branch@v1
         with:
           source: "beta"
           target: "main"

--- a/.github/workflows/reset_updates.yml
+++ b/.github/workflows/reset_updates.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Force push branch `beta` to `updates`
-        uses: jojomatik/sync-branch@v1
+        uses: johannes-huther/sync-branch@v1
         with:
           source: 'beta'
           target: 'updates'

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 by Crystal Creations GbR and jojomatik
+Copyright (c) 2022 by Crystal Creations GbR and Johannes Huther
 Copyright (c) 2017 by Simon Wuyts (https://codepen.io/simonwuyts/pen/mmMYzx)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@crystal-creations/animated-checkmark",
   "version": "2.1.0",
-  "author": "Crystal Creations GbR and jojomatik",
+  "author": "Crystal Creations GbR and Johannes Huther",
   "license": "MIT",
   "description": "A checkmark animation wrapped in a Vue component based on a codepen by Simon Wuyts",
   "scripts": {

--- a/src/AnimatedCheckmark.vue
+++ b/src/AnimatedCheckmark.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2022 by Crystal Creations GbR and jojomatik
+Copyright (c) 2022 by Crystal Creations GbR and Johannes Huther
 Copyright (c) 2017 by Simon Wuyts (https://codepen.io/simonwuyts/pen/mmMYzx)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and


### PR DESCRIPTION
Change the `LICENSE` and copyright notices to reflect the current copyright holder.

BREAKING CHANGE: Copyright holder changed

The copyright holder changed. If you have a copy of `LICENSE` in your local copy of the software, please update it to reflect the new copyright holder, when updating to the new version.