### PR TITLE
ci: run `semantic-release` job on next

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn build
 
   semantic-release:
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' }}
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/next' }}
     name: Create a semantic release
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Run `semantic-release` job for pushes to branch `next`.