### PR TITLE
test: let animation finish in `AnimatedCheckmark` story

### DIFF
--- a/stories/AnimatedCheckmark.stories.ts
+++ b/stories/AnimatedCheckmark.stories.ts
@@ -8,6 +8,9 @@ const meta: Meta<typeof AnimatedCheckmark> = {
       control: { type: "color", presetColors: ["red", "green", "blue"] },
     },
   },
+  parameters: {
+    chromatic: { pauseAnimationAtEnd: true },
+  },
 };
 
 export default meta;


### PR DESCRIPTION
Let the animation in the `AnimatedCheckmark` story finish before taking the screenshot, by pausing at the end of the animation.